### PR TITLE
fix: enforce HTTPS for remote API endpoints, allow HTTP only for loopback

### DIFF
--- a/tests/api-url-https-enforcement.test.js
+++ b/tests/api-url-https-enforcement.test.js
@@ -5,7 +5,7 @@ global.chrome = {
   storage: { local: { get(_, cb) { cb({}); } } }
 };
 
-const { buildModelApiRequest, isLocalOrPrivateUrl, ExtensionError } = require('../utils/common.js');
+const { buildModelApiRequest, isLoopbackUrl, ExtensionError } = require('../utils/common.js');
 
 const BASE_CONFIG = { apiKey: 'test-key', apiFormat: 'openai' };
 
@@ -25,29 +25,36 @@ function assertAllowed(baseUrl) {
 assertInsecureUrl('http://api.example.com');
 assertInsecureUrl('http://api.openai.com/v1');
 
+// Hostname-prefix bypass regression — must be blocked
+assertInsecureUrl('http://10.evil.example');
+assertInsecureUrl('http://172.16.evil.example');
+assertInsecureUrl('http://192.168.evil.example');
+assertInsecureUrl('http://127.0.0.1.evil.example');
+
+// RFC-1918 LAN addresses — blocked (policy: loopback only)
+assertInsecureUrl('http://192.168.1.100:8080/v1');
+assertInsecureUrl('http://10.0.0.1:11434/v1');
+assertInsecureUrl('http://172.16.0.5:8080/v1');
+
 // Remote HTTPS must pass
 assertAllowed('https://api.example.com/v1');
 assertAllowed('https://api.openai.com/v1');
 
-// Loopback must pass over plain HTTP
+// Loopback over HTTP must pass
 assertAllowed('http://localhost:11434/v1');
 assertAllowed('http://127.0.0.1:8080/v1');
+assertAllowed('http://127.0.0.99:8080/v1');
+assertAllowed('http://[::1]:8080/v1');
 
-// Private LAN ranges must pass over plain HTTP
-assertAllowed('http://192.168.1.100:8080/v1');
-assertAllowed('http://10.0.0.1:11434/v1');
-assertAllowed('http://172.16.0.5:8080/v1');
-
-// isLocalOrPrivateUrl unit checks
-assert.equal(isLocalOrPrivateUrl('http://localhost:11434'), true);
-assert.equal(isLocalOrPrivateUrl('http://127.0.0.1:8080'), true);
-assert.equal(isLocalOrPrivateUrl('http://::1:8080'), false); // ::1 as hostname only
-assert.equal(isLocalOrPrivateUrl('http://192.168.1.1'), true);
-assert.equal(isLocalOrPrivateUrl('http://10.0.0.1'), true);
-assert.equal(isLocalOrPrivateUrl('http://172.16.5.5'), true);
-assert.equal(isLocalOrPrivateUrl('http://172.15.5.5'), false);
-assert.equal(isLocalOrPrivateUrl('http://172.32.5.5'), false);
-assert.equal(isLocalOrPrivateUrl('http://api.example.com'), false);
+// isLoopbackUrl unit checks
+assert.equal(isLoopbackUrl('http://localhost:11434'), true);
+assert.equal(isLoopbackUrl('http://127.0.0.1:8080'), true);
+assert.equal(isLoopbackUrl('http://127.255.255.255'), true);
+assert.equal(isLoopbackUrl('http://[::1]:8080'), true);
+assert.equal(isLoopbackUrl('http://10.0.0.1'), false);
+assert.equal(isLoopbackUrl('http://192.168.1.1'), false);
+assert.equal(isLoopbackUrl('http://10.evil.example'), false);
+assert.equal(isLoopbackUrl('http://api.example.com'), false);
 
 // Non-regression: Authorization header is present in HTTPS request
 const req = buildModelApiRequest({ ...BASE_CONFIG, baseUrl: 'https://api.example.com/v1' }, 'hello');

--- a/tests/api-url-https-enforcement.test.js
+++ b/tests/api-url-https-enforcement.test.js
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+
+global.chrome = {
+  runtime: { lastError: null },
+  storage: { local: { get(_, cb) { cb({}); } } }
+};
+
+const { buildModelApiRequest, isLocalOrPrivateUrl, ExtensionError } = require('../utils/common.js');
+
+const BASE_CONFIG = { apiKey: 'test-key', apiFormat: 'openai' };
+
+function assertInsecureUrl(baseUrl) {
+  assert.throws(
+    () => buildModelApiRequest({ ...BASE_CONFIG, baseUrl }, 'hello'),
+    (err) => err instanceof ExtensionError && err.code === 'INSECURE_URL'
+  );
+}
+
+function assertAllowed(baseUrl) {
+  const result = buildModelApiRequest({ ...BASE_CONFIG, baseUrl }, 'hello');
+  assert.ok(result.url.startsWith(baseUrl));
+}
+
+// Remote HTTP must be blocked
+assertInsecureUrl('http://api.example.com');
+assertInsecureUrl('http://api.openai.com/v1');
+
+// Remote HTTPS must pass
+assertAllowed('https://api.example.com/v1');
+assertAllowed('https://api.openai.com/v1');
+
+// Loopback must pass over plain HTTP
+assertAllowed('http://localhost:11434/v1');
+assertAllowed('http://127.0.0.1:8080/v1');
+
+// Private LAN ranges must pass over plain HTTP
+assertAllowed('http://192.168.1.100:8080/v1');
+assertAllowed('http://10.0.0.1:11434/v1');
+assertAllowed('http://172.16.0.5:8080/v1');
+
+// isLocalOrPrivateUrl unit checks
+assert.equal(isLocalOrPrivateUrl('http://localhost:11434'), true);
+assert.equal(isLocalOrPrivateUrl('http://127.0.0.1:8080'), true);
+assert.equal(isLocalOrPrivateUrl('http://::1:8080'), false); // ::1 as hostname only
+assert.equal(isLocalOrPrivateUrl('http://192.168.1.1'), true);
+assert.equal(isLocalOrPrivateUrl('http://10.0.0.1'), true);
+assert.equal(isLocalOrPrivateUrl('http://172.16.5.5'), true);
+assert.equal(isLocalOrPrivateUrl('http://172.15.5.5'), false);
+assert.equal(isLocalOrPrivateUrl('http://172.32.5.5'), false);
+assert.equal(isLocalOrPrivateUrl('http://api.example.com'), false);
+
+// Non-regression: Authorization header is present in HTTPS request
+const req = buildModelApiRequest({ ...BASE_CONFIG, baseUrl: 'https://api.example.com/v1' }, 'hello');
+assert.ok(req.fetchOptions.headers['Authorization'].startsWith('Bearer '));

--- a/utils/common.js
+++ b/utils/common.js
@@ -527,6 +527,11 @@ function buildModelApiRequest(config = {}, prompt, options = {}) {
     throw new ExtensionError('API Key is required. Please configure it in settings.', 'API_KEY_MISSING');
   }
 
+  const urlValidation = validateUrl(baseUrl, ['https:']);
+  if (!urlValidation.valid) {
+    throw new ExtensionError('API Base URL must use HTTPS to protect API keys in transit.', 'INSECURE_URL');
+  }
+
   if (apiFormat === 'anthropic') {
     return {
       url: `${baseUrl}/messages`,

--- a/utils/common.js
+++ b/utils/common.js
@@ -507,6 +507,20 @@ function validateUrl(urlString, allowedProtocols = ['https:', 'http:']) {
   }
 }
 
+function isLocalOrPrivateUrl(urlString) {
+  try {
+    const { hostname } = new URL(urlString);
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
+    const parts = hostname.split('.').map(Number);
+    if (parts[0] === 10) return true;
+    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+    if (parts[0] === 192 && parts[1] === 168) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 function normalizeBaseUrl(baseUrl, fallback = 'https://api.openai.com/v1') {
   return String(baseUrl || fallback).trim().replace(/\/+$/, '');
 }
@@ -527,9 +541,15 @@ function buildModelApiRequest(config = {}, prompt, options = {}) {
     throw new ExtensionError('API Key is required. Please configure it in settings.', 'API_KEY_MISSING');
   }
 
-  const urlValidation = validateUrl(baseUrl, ['https:']);
+  const urlValidation = validateUrl(baseUrl);
   if (!urlValidation.valid) {
-    throw new ExtensionError('API Base URL must use HTTPS to protect API keys in transit.', 'INSECURE_URL');
+    throw new ExtensionError('API Base URL is not a valid URL.', 'INSECURE_URL');
+  }
+  if (new URL(baseUrl).protocol !== 'https:' && !isLocalOrPrivateUrl(baseUrl)) {
+    throw new ExtensionError(
+      'Remote API endpoints must use HTTPS to prevent network-level interception of API keys.',
+      'INSECURE_URL'
+    );
   }
 
   if (apiFormat === 'anthropic') {
@@ -819,6 +839,7 @@ if (typeof module !== 'undefined' && module.exports) {
     loadConfig,
     fetchWithTimeout,
     validateUrl,
+    isLocalOrPrivateUrl,
     normalizeBaseUrl,
     getApiFormat,
     buildModelApiRequest,

--- a/utils/common.js
+++ b/utils/common.js
@@ -507,15 +507,15 @@ function validateUrl(urlString, allowedProtocols = ['https:', 'http:']) {
   }
 }
 
-function isLocalOrPrivateUrl(urlString) {
+function isLoopbackUrl(urlString) {
   try {
     const { hostname } = new URL(urlString);
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
-    const parts = hostname.split('.').map(Number);
-    if (parts[0] === 10) return true;
-    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
-    if (parts[0] === 192 && parts[1] === 168) return true;
-    return false;
+    if (hostname === 'localhost' || hostname === '[::1]') return true;
+    const parts = hostname.split('.');
+    if (parts.length !== 4) return false;
+    const nums = parts.map(Number);
+    if (nums.some(n => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+    return nums[0] === 127;
   } catch {
     return false;
   }
@@ -545,9 +545,9 @@ function buildModelApiRequest(config = {}, prompt, options = {}) {
   if (!urlValidation.valid) {
     throw new ExtensionError('API Base URL is not a valid URL.', 'INSECURE_URL');
   }
-  if (new URL(baseUrl).protocol !== 'https:' && !isLocalOrPrivateUrl(baseUrl)) {
+  if (new URL(baseUrl).protocol !== 'https:' && !isLoopbackUrl(baseUrl)) {
     throw new ExtensionError(
-      'Remote API endpoints must use HTTPS to prevent network-level interception of API keys.',
+      'Non-loopback API endpoints must use HTTPS to prevent network-level interception of API keys.',
       'INSECURE_URL'
     );
   }
@@ -839,7 +839,7 @@ if (typeof module !== 'undefined' && module.exports) {
     loadConfig,
     fetchWithTimeout,
     validateUrl,
-    isLocalOrPrivateUrl,
+    isLoopbackUrl,
     normalizeBaseUrl,
     getApiFormat,
     buildModelApiRequest,


### PR DESCRIPTION
### Summary

`buildModelApiRequest` now requires HTTPS for all API base URLs except loopback addresses (`localhost`, `127.0.0.0/8`, `[::1]`), which may continue to use plain HTTP for local development (e.g. Ollama, LM Studio, or other self-hosted endpoints running on the same machine).

This replaces the original blanket "HTTPS-only" restriction, which would have broken any locally-hosted model backend, per feedback on the initial version of this PR.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `utils/common.js:490` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

### Changes

- `utils/common.js`
  - Added `isLoopbackUrl()`: strictly validates loopback addresses via numeric dotted-quad parsing (`127.0.0.0/8`), `localhost`, and `[::1]` — no string-prefix or substring matching.
  - `buildModelApiRequest` now throws `INSECURE_URL` only when the base URL is both non-HTTPS *and* non-loopback.
- `tests/api-url-https-enforcement.test.js` (new)
  - Remote HTTP endpoints are rejected; remote HTTPS endpoints pass.
  - Loopback endpoints (`localhost`, `127.0.0.1`, `[::1]`, other `127.x.x.x`) pass over HTTP.
  - Private LAN ranges (`10.x`, `172.16-31.x`, `192.168.x`) now require HTTPS, same as any other remote host.
  - Regression coverage for a hostname-prefix bypass (e.g. `http://10.evil.example`, `http://192.168.evil.example`) that would have slipped through an earlier, less strict private-IP check.
  - Confirms `Authorization` header behavior is unchanged for HTTPS requests.


### Notes

An earlier iteration of this fix also allowed private LAN ranges (10.x/172.16-31.x/192.168.x) over HTTP. That check parsed hostnames by splitting on `.` and comparing the first segment numerically, which meant a publicly-resolvable domain like `10.evil.example` would incorrectly pass as "private." This version removes the LAN allowance and restricts the HTTP exemption to strict, correctly-validated loopback addresses only — private/LAN endpoints must use HTTPS.

---
Automated security fix by [OrbisAI Security](https://orbisappsec.com)
